### PR TITLE
Adds Rspecs for Overridden Devise Finder Method

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
+--format Fuubar
 --color
 --require spec_helper
 --require rails_helper

--- a/Gemfile
+++ b/Gemfile
@@ -28,11 +28,18 @@ gem 'seed-fu'
 group :development, :test do
   gem 'byebug'
   gem "rspec-rails"
+  gem "database_cleaner"
+  gem 'factory_girl_rails'
+  gem "awesome_print"
+  gem 'shoulda-matchers'
 end
 
 group :test do
   gem 'simplecov', require: false
   gem 'coveralls', require: false
+  gem 'rspec-its'
+  gem 'should_not'
+  gem 'fuubar'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.3)
+    awesome_print (1.2.0)
     bcrypt (3.1.10)
     better_errors (2.0.0)
       coderay (>= 1.0.0)
@@ -64,6 +65,7 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     devise (3.5.2)
       bcrypt (~> 3.0)
@@ -76,8 +78,16 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.6.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     font-awesome-rails (4.4.0.0)
       railties (>= 3.2, < 5.0)
+    fuubar (2.0.0)
+      rspec (~> 3.0)
+      ruby-progressbar (~> 1.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     haml (4.0.5)
@@ -148,11 +158,18 @@ GEM
     rest-client (1.7.2)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.1.0)
+    rspec-its (1.1.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-rails (3.1.0)
@@ -164,6 +181,7 @@ GEM
       rspec-mocks (~> 3.1.0)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    ruby-progressbar (1.7.0)
     sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -177,6 +195,9 @@ GEM
     seed-fu (2.3.5)
       activerecord (>= 3.1, < 4.3)
       activesupport (>= 3.1, < 4.3)
+    should_not (1.1.0)
+    shoulda-matchers (2.7.0)
+      activesupport (>= 3.0.0)
     simplecov (0.9.1)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -215,22 +236,29 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store
+  awesome_print
   better_errors
   byebug
   coffee-rails (~> 4.1.0)
   coveralls
+  database_cleaner
   devise
+  factory_girl_rails
   font-awesome-rails (~> 4.4.0.0)
+  fuubar
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
   pg
   rails (= 4.2.4)
   rails_12factor
+  rspec-its
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   seed-fu
+  should_not
+  shoulda-matchers
   simplecov
   spring
   turbolinks

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,23 +1,15 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+  devise :database_authenticatable, :trackable, :validatable, :timeoutable, :lockable
 
-  protected
+  class << self
 
-    def email_required?
-      false
+    def find_for_database_authentication(conditions)
+      username = conditions[:username] || ''
+      where(["lower(username) = :value", { :value => username }]).first
     end
 
-    def email_changed?
-      false
-    end
-
-    def self.find_for_database_authentication(warden_conditions)
-      conditions = warden_conditions.dup
-      login = conditions.delete(:username)
-      where(conditions).where(["lower(username) = :value", { :value => login.downcase }]).first
-    end
+  end
 
 end

--- a/db/fixtures/01_users.rb
+++ b/db/fixtures/01_users.rb
@@ -1,4 +1,4 @@
 User.seed(:id,
-  { id: 1, username: 'craig.lenzen@payit.com', password: 'payit123', password_confirmation: 'payit123' },
-  { id: 2, username: 'david.lenzen@payit.com', password: 'payit123', password_confirmation: 'payit123' }
+  { id: 1, username: 'craig.lenzen@payit.com', email: 'craig.lenzen@payit.com', password: 'payit123', password_confirmation: 'payit123' },
+  { id: 2, username: 'david.lenzen@payit.com', email: 'david.lenzen@payit.com', password: 'payit123', password_confirmation: 'payit123' }
 )

--- a/db/migrate/20151020131248_devise_create_users.rb
+++ b/db/migrate/20151020131248_devise_create_users.rb
@@ -3,6 +3,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
     create_table(:users) do |t|
       ## Database authenticatable
       t.string :username, null: false, :limit => 100
+      t.string :email, null: false, :limit => 255
       t.string :encrypted_password, null: false, :limit => 255
 
       ## Recoverable

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20151020131248) do
 
   create_table "users", force: :cascade do |t|
     t.string   "username",               limit: 100,             null: false
+    t.string   "email",                  limit: 255,             null: false
     t.string   "encrypted_password",     limit: 255,             null: false
     t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :user do
+    sequence(:username) { |n| "username#{n}@payit.com" }
+    email { username }
+    password "pwd12345"
+    encrypted_password "pwd12345"
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,27 @@
-require 'rails_helper'
-
 RSpec.describe User, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe "#find_for_database_authentication" do
+
+    let(:user) { create :user }
+    let(:conditions) { {username: user.username} }
+    subject { User.find_for_database_authentication conditions }
+
+    context "when conditions hash contains username" do
+      context "and user exists" do
+        it { should_not be_nil }
+        it { should eq user }
+      end
+      context "and user does not exist" do
+        let(:conditions) { {username: "doesnotexist@payit.com"} }
+        it { should be_nil }
+      end
+    end
+
+    context "when conditions hash does not contain username" do
+      let(:conditions) { {} }
+      it { should be_nil }
+    end
+
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,14 +3,30 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'rspec/its'
+require 'devise'
 
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
 
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  config.use_transactional_fixtures = true
-
+  config.use_transactional_fixtures = false
+  config.use_instantiated_fixtures  = false
+  config.mock_with :rspec
   config.infer_spec_type_from_file_location!
+
+  config.include FactoryGirl::Syntax::Methods
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+    # FactoryGirl.lint
+  end
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+  config.after(:each) do |x|
+    DatabaseCleaner.clean
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,15 +5,21 @@ else
   require 'simplecov'
   SimpleCov.start 'rails'
 end
+require 'devise'
 
 RSpec.configure do |config|
 
-  config.expect_with :rspec do |expectations|
-    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  config.alias_it_should_behave_like_to :it_validates, "it_validates"
+  config.alias_it_should_behave_like_to :it_raises, "it_raises"
+  config.alias_it_should_behave_like_to :it_raises_error, "it_raises_error"
+
+  module OneLinerExpectSyntax
+    def expects(subject)
+      expect(subject)
+    end
   end
 
-  config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = true
-  end
+  config.include OneLinerExpectSyntax
+  config.include Devise::TestHelpers, :type => :controller
 
 end


### PR DESCRIPTION
Since we are using "username" to authenticate instead of "email" we needed to override "find_for_database_authentication" to look up a User by "username".  This branch just generally sets up PayIt application for further unit testing and added specs for this overridden method.
